### PR TITLE
fix: コメント位置が意図しない位置に移動する問題を修正

### DIFF
--- a/src/content/managers/layout.ts
+++ b/src/content/managers/layout.ts
@@ -18,8 +18,16 @@ export function insertSecondary(elements: YoutubeElements): void {
     if (largeLayoutPosition === "large-position-leftside") {
       secondaryInner.insertBefore(comments, secondaryInner.firstChild);
     }
+    if (!secondaryInner.contains(related)) {
+      secondaryInner.appendChild(related);
+    }
     else if (largeLayoutPosition === "large-position-leftside-bottom") {
-      secondaryInner.insertBefore(comments, related);
+      if (secondaryInner.contains(related)) {
+        secondaryInner.insertBefore(comments, related);
+      } else {
+        secondaryInner.appendChild(comments);
+        secondaryInner.appendChild(related);
+      }
     }
     else if (largeLayoutPosition === "large-position-switch") {
       secondaryInner.appendChild(comments);

--- a/src/content/utils/height.ts
+++ b/src/content/utils/height.ts
@@ -2,13 +2,7 @@ import { settings, getLayoutSettings } from "../state";
 import { setSettings } from "../../settings";
 
 export function isLargeScreenLayout(): boolean {
-  const pageManager = document.querySelectorAll<HTMLElement>("#page-manager > ytd-watch-flexy")[0];
-  if (!pageManager) return false;
-
-  const isTwoColumn = pageManager.attributes["default-two-column-layout" as keyof typeof pageManager.attributes];
-  const isTwoColumns = pageManager.attributes["is-two-columns_" as keyof typeof pageManager.attributes];
-
-  return !(isTwoColumn === undefined) && !(isTwoColumns === undefined);
+  return window.innerWidth >= 1017;
 }
 
 export function calculateHeight(): number {


### PR DESCRIPTION
シアターモード解除時に，コメントが意図しない位置へ移動する問題を修正した．

原因

レイアウト変更の検出を pageManager 要素で行っていたが，シアターモード時に large レイアウトであるにもかかわらず medium レイアウトとして検知されていた．
その結果，コメント位置の再配置処理が誤って実行され，位置が動的に変わってしまっていた．

修正内容

- レイアウト変更の検出をウィンドウ幅（1017px以上）で判定するように変更し，シアターモードの影響を受けずに isLargeScreenLayout 関数が正しく動作するようにした
- レイアウト変更時に insertBefore でエラーが発生しないよう，例外的なケースに備えたガード処理を追加した