### PR TITLE
refactor: 設定構造を簡素化し識別子を短縮

### DIFF
--- a/public/popup.html
+++ b/public/popup.html
@@ -123,31 +123,30 @@
           </div>
 
           <div class="d-flex align-items-center justify-content-between my-3">
-            <label for="large-height-comments" class="m-auto form-label text-nowrap">コメント欄の高さ：</label>
-            <input type="number" class="mx-2 form-control form-control-sm" id="large-height-comments" min="0"
-              max="1000">
+            <label for="large-height" class="m-auto form-label text-nowrap">コメント欄の高さ：</label>
+            <input type="number" class="mx-2 form-control form-control-sm" id="large-height" min="0" max="1000">
             <div class="m-auto">px</div>
           </div>
 
           <div class="d-flex align-items-center justify-content-between">
-            <label for="large-layout-position " class="form-label text-nowrap  m-auto">コメント欄の配置：</label>
-            <select id="large-layout-position" class="form-select form-select-sm" aria-label="large-layout">
-              <option value="large-position-default">デフォルト</option>
-              <option value="large-position-leftside">サイドバー</option>
-              <option value="large-position-leftside-bottom">サイドバー（チャットや再生リスト等の下）</option>
-              <option value="large-position-switch">コメントと関連動画を入れ替える</option>
+            <label for="large-position " class="form-label text-nowrap  m-auto">コメント欄の配置：</label>
+            <select id="large-position" class="form-select form-select-sm" aria-label="large-layout">
+              <option value="large-default">デフォルト</option>
+              <option value="large-secondary">サイドバー</option>
+              <option value="large-secondary-bottom">サイドバー（チャットや再生リスト等の下）</option>
+              <option value="large-switch">コメントと関連動画を入れ替える</option>
             </select>
           </div>
 
           <div class="form-check mt-3">
             <input class="form-check-input large-layout-option" type="checkbox" data-id="stickyPlayer" value=""
-              id="large-layout-sticky-player-option">
-            <label class="form-check-label text-nowrap" for="large-layout-sticky-player-option">
+              id="large-sticky-player">
+            <label class="form-check-label text-nowrap" for="large-sticky-player">
               スクロール時，動画プレイヤーを固定する（オプション）
             </label><br>
             <input class="form-check-input large-layout-option" type="checkbox" data-id="stickyComments" value=""
-              id="large-layout-sticky-comments-option">
-            <label class="form-check-label text-nowrap" for="large-layout-sticky-comments-option">
+              id="large-sticky-comments">
+            <label class="form-check-label text-nowrap" for="large-sticky-comments">
               コメントのヘッダを固定する（オプション）
             </label>
           </div>
@@ -164,30 +163,29 @@
           </div>
 
           <div class="d-flex align-items-center justify-content-between my-3">
-            <label for="medium-height-comments" class="m-auto form-label text-nowrap">コメント欄の高さ：</label>
-            <input type="number" class="mx-2 form-control form-control-sm" id="medium-height-comments" min="0"
-              max="1000">
+            <label for="medium-height" class="m-auto form-label text-nowrap">コメント欄の高さ：</label>
+            <input type="number" class="mx-2 form-control form-control-sm" id="medium-height" min="0" max="1000">
             <div class="m-auto">px</div>
           </div>
 
           <div class="d-flex align-items-center justify-content-between">
-            <label for="medium-layout-position " class="form-label text-nowrap m-auto">コメント欄の配置：</label>
-            <select id="medium-layout-position" class="form-select form-select-sm" aria-label="medium-layout">
-              <option value="medium-position-default">デフォルト</option>
-              <option value="medium-position-undermetadata">動画メタデータの下</option>
-              <option value="medium-position-underplayer">動画プレイヤーの下</option>
+            <label for="medium-position " class="form-label text-nowrap m-auto">コメント欄の配置：</label>
+            <select id="medium-position" class="form-select form-select-sm" aria-label="medium-layout">
+              <option value="medium-default">デフォルト</option>
+              <option value="medium-undermetadata">動画メタデータの下</option>
+              <option value="medium-underplayer">動画プレイヤーの下</option>
             </select>
           </div>
 
           <div class="form-check mt-3">
             <input class="form-check-input medium-layout-option" type="checkbox" data-id="stickyPlayer" value=""
-              id="medium-layout-sticky-player-option">
-            <label class="form-check-label text-nowrap" for="medium-layout-sticky-player-option">
+              id="medium-sticky-player">
+            <label class="form-check-label text-nowrap" for="medium-sticky-player">
               スクロール時，動画プレイヤーを固定する（オプション）
             </label><br>
             <input class="form-check-input medium-layout-option" type="checkbox" data-id="stickyComments" value=""
-              id="medium-layout-sticky-comments-option">
-            <label class="form-check-label text-nowrap" for="medium-layout-sticky-comments-option">
+              id="medium-sticky-comments">
+            <label class="form-check-label text-nowrap" for="medium-sticky-comments">
               コメントのヘッダを固定する（オプション）
             </label>
           </div>

--- a/src/content/managers/layout.ts
+++ b/src/content/managers/layout.ts
@@ -15,13 +15,13 @@ export function insertSecondary(elements: YoutubeElements): void {
   applyCommentStyles(comments, isLargeDefaultPosition);
 
   if (!isLargeDefaultPosition) {
-    if (largeLayoutPosition === "large-position-leftside") {
+    if (largeLayoutPosition === "large-secondary") {
       secondaryInner.insertBefore(comments, secondaryInner.firstChild);
     }
     if (!secondaryInner.contains(related)) {
       secondaryInner.appendChild(related);
     }
-    else if (largeLayoutPosition === "large-position-leftside-bottom") {
+    else if (largeLayoutPosition === "large-secondary-bottom") {
       if (secondaryInner.contains(related)) {
         secondaryInner.insertBefore(comments, related);
       } else {
@@ -29,7 +29,7 @@ export function insertSecondary(elements: YoutubeElements): void {
         secondaryInner.appendChild(related);
       }
     }
-    else if (largeLayoutPosition === "large-position-switch") {
+    else if (largeLayoutPosition === "large-switch") {
       secondaryInner.appendChild(comments);
       setTimeout(() => {
         below.appendChild(related);
@@ -56,9 +56,9 @@ export function insertPrimary(elements: YoutubeElements): void {
     return;
   }
 
-  if (mediumLayoutPosition === "medium-position-underplayer") {
+  if (mediumLayoutPosition === "medium-underplayer") {
     below.insertBefore(comments, metaData);
-  } else if (mediumLayoutPosition === "medium-position-undermetadata") {
+  } else if (mediumLayoutPosition === "medium-undermetadata") {
     below.appendChild(comments);
   }
 

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -38,16 +38,16 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
 });
 
 export function getLayoutSettings() {
-  const large = settings.largeLayout;
-  const medium = settings.mediumLayout;
+  const large = settings.large;
+  const medium = settings.medium;
 
   return {
-    isLargeDefaultPosition: large.position === "large-position-default",
-    isLargeStickyPlayer: large.options.stickyPlayer.option,
-    isLargeStickyComments: large.options.stickyComments.option,
-    isMediumDefaultPosition: medium.position === "medium-position-default",
-    isMediumStickyPlayer: medium.options.stickyPlayer.option,
-    isMediumStickyComments: medium.options.stickyComments.option,
+    isLargeDefaultPosition: large.position === "large-default",
+    isLargeStickyPlayer: large.stickyPlayer,
+    isLargeStickyComments: large.stickyComments,
+    isMediumDefaultPosition: medium.position === "medium-default",
+    isMediumStickyPlayer: medium.stickyPlayer,
+    isMediumStickyComments: medium.stickyComments,
     largeLayoutPosition: large.position,
     mediumLayoutPosition: medium.position,
     largeHeight: large.height,

--- a/src/content/utils/height.ts
+++ b/src/content/utils/height.ts
@@ -15,10 +15,10 @@ export function calculateHeight(): number {
 
   if (isLargeScreen) {
     height = getLayoutSettings().largeHeight;
-    settings.largeLayout.height = height ? height : windowHeight - headerHeight - 155;
+    settings.large.height = height ? height : windowHeight - headerHeight - 155;
   } else {
     height = getLayoutSettings().mediumHeight;
-    settings.mediumLayout.height = height ? height : windowHeight - headerHeight - 205;
+    settings.medium.height = height ? height : windowHeight - headerHeight - 205;
   }
 
   setSettings(settings);

--- a/src/popup/manager.ts
+++ b/src/popup/manager.ts
@@ -92,12 +92,12 @@ export class PopupManager {
     });
 
     // レイアウト設定のイベントリスナー
-    const layouts: Layout[] = ['largeLayout', 'mediumLayout'];
+    const layouts: Layout[] = ['large', 'medium'];
     layouts.forEach((layout: Layout) => {
       const layoutSetting: LayoutSetting = this.settings[layout];
-      const heightInput = document.getElementById(layoutSetting.heightId) as HTMLInputElement | null;
-      const positionEl = document.getElementById(layoutSetting.positionId) as HTMLSelectElement | null;
-      const imageEl = document.getElementById(layoutSetting.positionImgId) as HTMLImageElement | null;
+      const heightInput = document.getElementById(`${layout}-height`) as HTMLInputElement | null;
+      const positionEl = document.getElementById(`${layout}-position`) as HTMLSelectElement | null;
+      const imageEl = document.getElementById(`${layout}-image`) as HTMLImageElement | null;
       if (positionEl && heightInput && imageEl) {
         positionEl.addEventListener('change', () => {
           const selectedPosition = positionEl.value as keyof typeof IMG_MAP;
@@ -106,7 +106,7 @@ export class PopupManager {
             [layout]: {
               ...layoutSetting,
               position: selectedPosition,
-              positionImage: IMG_MAP[selectedPosition] || layoutSetting.positionImage,
+              img: IMG_MAP[selectedPosition] || layoutSetting.img,
             }
           };
           this.updateSettings(patch, 'レイアウトの位置を保存しました', 'レイアウトの位置の保存に失敗しました');
@@ -125,21 +125,15 @@ export class PopupManager {
       }
 
       // オプション設定のイベントリスナー
-      Object.values(layoutSetting.options).forEach(option => {
-        const optionEl = document.getElementById(option.id) as HTMLInputElement | null;
-        optionEl?.addEventListener('change', (e) => {
+      const optionIds = ['stickyPlayer', 'stickyComments'] as const;
+      optionIds.forEach(optionId => {
+        const optionEl = document.getElementById(`${layout}-sticky-${optionId === 'stickyPlayer' ? 'player' : 'comments'}`) as HTMLInputElement | null;
+        optionEl?.addEventListener('change', () => {
           const value = optionEl.checked;
-          const property = (e.target as HTMLInputElement).dataset.id || '';
           const patch: Partial<Settings> = {
             [layout]: {
               ...layoutSetting,
-              options: {
-                ...layoutSetting.options,
-                [property]: {
-                  id: option.id,
-                  option: value,
-                }
-              }
+              [optionId]: value,
             }
           };
           this.updateSettings(patch, 'オプション設定を保存しました', 'オプション設定の保存に失敗しました');
@@ -183,28 +177,26 @@ export class PopupManager {
   private setupSettingsUI(): void {
     const setLayout = (layout: Layout): void => {
       const layoutSettings: LayoutSetting = this.settings[layout];
-      const heightInput = document.getElementById(layoutSettings.heightId) as HTMLInputElement | null;
-      const positionEl = document.getElementById(layoutSettings.positionId) as HTMLSelectElement | null;
-      const image = document.getElementById(layoutSettings.positionImgId) as HTMLImageElement | null;
+      const heightInput = document.getElementById(`${layout}-height`) as HTMLInputElement | null;
+      const positionEl = document.getElementById(`${layout}-position`) as HTMLSelectElement | null;
+      const image = document.getElementById(`${layout}-image`) as HTMLImageElement | null;
       if (positionEl && heightInput && image) {
         heightInput.value = layoutSettings.height !== null ? String(layoutSettings.height) : '';
         positionEl.value = layoutSettings.position;
-        image.src = layoutSettings.positionImage;
+        image.src = layoutSettings.img;
       }
     };
     const setOptions = (layout: Layout): void => {
       const layoutSettings: LayoutSetting = this.settings[layout];
-      Object.values(layoutSettings.options).forEach(option => {
-        const optionEl = document.getElementById(option.id) as HTMLInputElement | null;
-        if (optionEl) {
-          optionEl.checked = option.option;
-        }
-      });
+      const stickyPlayerEl = document.getElementById(`${layout}-sticky-player`) as HTMLInputElement | null;
+      const stickyCommentsEl = document.getElementById(`${layout}-sticky-comments`) as HTMLInputElement | null;
+      if (stickyPlayerEl) stickyPlayerEl.checked = layoutSettings.stickyPlayer;
+      if (stickyCommentsEl) stickyCommentsEl.checked = layoutSettings.stickyComments;
     };
-    setLayout('largeLayout');
-    setLayout('mediumLayout');
-    setOptions('largeLayout');
-    setOptions('mediumLayout');
+    setLayout('large');
+    setLayout('medium');
+    setOptions('large');
+    setOptions('medium');
   }
 
   private setupMoreMenu(): void {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,4 +1,55 @@
 export type Position =
+  | 'large-default'
+  | 'large-secondary'
+  | 'large-secondary-bottom'
+  | 'large-switch'
+  | 'medium-default'
+  | 'medium-undermetadata'
+  | 'medium-underplayer';
+
+export type LayoutSetting = {
+  position: Position;
+  img: string;
+  height: number | null;
+  stickyPlayer: boolean;
+  stickyComments: boolean;
+}
+
+export type Layout = "large" | "medium";
+
+export type Settings = {
+  [key in Layout]: LayoutSetting;
+};
+
+export const IMG_MAP: Record<Position, string> = {
+  "large-default": "./images/large-layout-comments-default.png",
+  "large-secondary": "./images/large-layout-comments-secondary.png",
+  "large-secondary-bottom": "./images/large-layout-comments-secondary-bottom.png",
+  "large-switch": "./images/large-layout-comments-related-switch.png",
+  "medium-default": "./images/medium-layout-comments-default.png",
+  "medium-undermetadata": "./images/medium-layout-comments-under-metadata.png",
+  "medium-underplayer": "./images/medium-layout-comments-under-player.png",
+};
+
+export const DEFAULT_SETTINGS: Settings = {
+  large: {
+    position: "large-secondary",
+    img: IMG_MAP["large-secondary"],
+    height: null,
+    stickyPlayer: false,
+    stickyComments: false,
+  },
+  medium: {
+    position: "medium-default",
+    img: IMG_MAP["medium-default"],
+    height: null,
+    stickyPlayer: false,
+    stickyComments: false,
+  }
+}
+
+// レガシー型定義（マイグレーション用）
+type LegacyPosition =
   | 'large-position-default'
   | 'large-position-leftside'
   | 'large-position-leftside-bottom'
@@ -7,7 +58,7 @@ export type Position =
   | 'medium-position-undermetadata'
   | 'medium-position-underplayer';
 
-type Options = {
+type LegacyOptions = {
   stickyPlayer: {
     id: string;
     option: boolean;
@@ -18,78 +69,109 @@ type Options = {
   };
 }
 
-export type LayoutSetting = {
+type LegacyLayoutSetting = {
   positionId: string;
-  position: Position;
+  position: LegacyPosition;
   positionImgId: string;
   positionImage: string;
   heightId: string;
   height: number | null;
-  options: Options;
-  positionPrefix: "large" | "medium";
+  options: LegacyOptions;
+  positionPrefix: string;
 }
 
-export type Layout = "largeLayout" | "mediumLayout";
+type LegacySettings = {
+  largeLayout?: LegacyLayoutSetting;
+  mediumLayout?: LegacyLayoutSetting;
+}
 
-export type Settings = {
-  [key in Layout]: LayoutSetting;
-};
+// レガシーpositionを新しいpositionに変換
+function migratePosition(oldPosition: string): Position {
+  const map: Record<string, Position> = {
+    'large-position-default': 'large-default',
+    'large-position-leftside': 'large-secondary',
+    'large-position-leftside-bottom': 'large-secondary-bottom',
+    'large-position-switch': 'large-switch',
+    'medium-position-default': 'medium-default',
+    'medium-position-undermetadata': 'medium-undermetadata',
+    'medium-position-underplayer': 'medium-underplayer',
+    // 開発中の一時的な形式（念のため対応）
+    'large-leftside': 'large-secondary',
+    'large-leftside-bottom': 'large-secondary-bottom',
+  };
+  return map[oldPosition] || oldPosition as Position;
+}
 
-export const IMG_MAP: Record<Position, string> = {
-  "large-position-default": "./images/large-layout-comments-default.png",
-  "large-position-leftside": "./images/large-layout-comments-secondary.png",
-  "large-position-leftside-bottom": "./images/large-layout-comments-secondary-bottom.png",
-  "large-position-switch": "./images/large-layout-comments-related-switch.png",
-  "medium-position-default": "./images/medium-layout-comments-default.png",
-  "medium-position-undermetadata": "./images/medium-layout-comments-under-metadata.png",
-  "medium-position-underplayer": "./images/medium-layout-comments-under-player.png",
-};
+// レガシー設定を新しい形式に変換
+function migrateSettings(data: any): Settings {
+  const legacy = data as LegacySettings;
 
-export const DEFAULT_SETTINGS: Settings = {
-  largeLayout: {
-    positionId: "large-layout-position",
-    position: "large-position-leftside",
-    positionImgId: "large-image",
-    positionImage: IMG_MAP["large-position-leftside"],
-    heightId: "large-height-comments",
-    height: null,
-    options: {
-      stickyPlayer: {
-        id: "large-layout-sticky-player-option",
-        option: false,
+  // 旧形式（largeLayout/mediumLayoutを使用）を検出してマイグレーション
+  if (legacy.largeLayout && legacy.mediumLayout) {
+    return {
+      large: {
+        position: migratePosition(legacy.largeLayout.position),
+        img: legacy.largeLayout.positionImage,
+        height: legacy.largeLayout.height,
+        stickyPlayer: legacy.largeLayout.options.stickyPlayer.option,
+        stickyComments: legacy.largeLayout.options.stickyComments.option,
       },
-      stickyComments: {
-        id: "large-layout-sticky-comments-option",
-        option: false,
+      medium: {
+        position: migratePosition(legacy.mediumLayout.position),
+        img: legacy.mediumLayout.positionImage,
+        height: legacy.mediumLayout.height,
+        stickyPlayer: legacy.mediumLayout.options.stickyPlayer.option,
+        stickyComments: legacy.mediumLayout.options.stickyComments.option,
       }
-    },
-    positionPrefix: "large",
-  },
-  mediumLayout: {
-    positionId: "medium-layout-position",
-    position: "medium-position-default",
-    positionImgId: "medium-image",
-    positionImage: IMG_MAP["medium-position-default"],
-    heightId: "medium-height-comments",
-    height: null,
-    options: {
-      stickyPlayer: {
-        id: "medium-layout-sticky-player-option",
-        option: false,
-      },
-      stickyComments: {
-        id: "medium-layout-sticky-comments-option",
-        option: false,
-      }
-    },
-    positionPrefix: "medium",
+    };
   }
+
+  // 新形式でも古いposition値を含む可能性があるため変換
+  if (data.large && data.medium) {
+    return {
+      large: {
+        ...data.large,
+        position: migratePosition(data.large.position),
+      },
+      medium: {
+        ...data.medium,
+        position: migratePosition(data.medium.position),
+      }
+    };
+  }
+
+  return DEFAULT_SETTINGS;
 }
 
 
 export async function getSettings(): Promise<Settings> {
-  const data = await getStorage<{ settings?: Settings }>('settings');
-  return data.settings ?? DEFAULT_SETTINGS;
+  const data = await getStorage<{ settings?: any }>('settings');
+  if (!data.settings) {
+    return DEFAULT_SETTINGS;
+  }
+
+  // マイグレーション実行
+  const migratedSettings = migrateSettings(data.settings);
+
+  // マイグレーションが必要だったかチェック
+  const needsMigration =
+    data.settings.largeLayout ||
+    data.settings.mediumLayout ||
+    (data.settings.large && (
+      data.settings.large.position?.includes('position-') ||
+      data.settings.large.position === 'large-leftside' ||
+      data.settings.large.position === 'large-leftside-bottom'
+    )) ||
+    (data.settings.medium && (
+      data.settings.medium.position?.includes('position-')
+    ));
+
+  // マイグレーションが必要だった場合は新しい形式で保存
+  if (needsMigration) {
+    await setStorage({ settings: migratedSettings });
+  }
+
+  return migratedSettings;
 }
 
 export async function isEnabled(): Promise<boolean> {


### PR DESCRIPTION
設定構造をフラット化し，キー名および識別子を簡素化した．
既存のユーザ設定は自動的にマイグレーションされる．

変更内容:

- `largeLayout` → `large`
- `options.stickyPlayer.option` → `stickyPlayer`
- `large-position-leftside` → `large-secondary`
- 不要なIDプロパティ（`positionId`, `heightId` など）を削除
- `positionImage` → `img`
- 既存ユーザ設定を保持するマイグレーション機能を追加

破壊的変更:

設定構造が変更されているが，自動マイグレーションが含まれているため，既存設定は引き継がれる．