### PR TITLE
chore: tsconfig に chrome/node型を追加しCSS import対応を追加

### DIFF
--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "target": "ES2021",
     "lib": ["ES2021", "DOM"],
+    "types": ["chrome", "node"],
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "strict": true,
     "outDir": "dist",
     "esModuleInterop": true,


### PR DESCRIPTION
tsconfig に `chrome` と `node` の型定義を追加し，CSS import を型的に扱えるように `src/types/css.d.ts` を追加した．
これにより，型チェックおよびビルド時のモジュール解決が安定する．