### PR TITLE
fix: サイドバー幅調整時に動画がはみ出す問題を修正

### DIFF
--- a/src/content/content.css
+++ b/src/content/content.css
@@ -72,5 +72,4 @@ ytd-watch-flexy.ycp-custom-sidebar-width {
 
 video.ycp-custom-sidebar-width {
   height: auto !important;
-  width: 100% !important;
 }


### PR DESCRIPTION
#13 で報告されている，「サイドバーの幅を調整する（β機能）」有効時に，正方形の動画が拡大されて表示領域からはみ出す問題を修正した．

原因は，動画要素に指定していた `width: 100% !important;` により，YouTube の自動サイズ調整が無効化されていたことだった．

このスタイルを削除し，YouTube 側のレイアウト制御を優先するように変更した．

Fixes #13