### PR TITLE
fix: 動画ページ遷移後にサイドバー幅調整できない問題を修正

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -21,7 +21,10 @@ const observer = new MutationObserver(() => {
 
   const isLargeScreen = isLargeScreenLayout();
 
-  if (!isReloaded) {
+  const url = new URL(window.location.href);
+  const currentVideoId = url.searchParams.get("v");
+
+  if (!isReloaded && currentVideoId) {
     handleFirstRender(elements, isLargeScreen);
     applyLayout(elements, isLargeScreen);
     setIsReloaded(true);
@@ -34,9 +37,6 @@ const observer = new MutationObserver(() => {
       applyLayout(elements, isLargeScreen);
     }
   }
-
-  const url = new URL(window.location.href);
-  const currentVideoId = url.searchParams.get("v");
 
   if (preUrl !== currentVideoId) {
     handleFirstRender(elements, isLargeScreen);


### PR DESCRIPTION
#17 で報告されている問題を修正した．

原因は，トップページでドラッグ用の要素が挿入されているにもかかわらず，`handleDrag` のイベントリスナが正しく登録されていなかったことである．

対応として，ドラッグ要素および関連処理を動画ページでのみ初期化するように変更した．これにより，不要な要素の挿入を防ぎつつ，正常に幅調整できるようになった．

Fixes #17