### PR TITLE
fix: コメント入力欄が透過する問題を修正

### DIFF
--- a/src/content/content.css
+++ b/src/content/content.css
@@ -30,7 +30,7 @@
   position: sticky !important;
   top: 0 !important;
   z-index: 999 !important;
-  background: var(--yt-spec-base-background) !important;
+  background: var(--t3e41d7b17b187f69) !important;
   padding-bottom: 5px !important;
 }
 


### PR DESCRIPTION
コメントヘッダ（入力欄）固定オプション使用時においてスクロール時に透過する問題について対応した．
以前はダークモード対応のため YouTube の内部 CSS 変数を参照していたが，当該変数を利用できなくなったことが原因であったためである．
該当箇所を修正し，固定された状態でもコメントヘッダが常に不透明な状態で表示されるよう修正した．